### PR TITLE
Added Bundled with GitLens VSCode version number 

### DIFF
--- a/MCP/MCP-getting-started.md
+++ b/MCP/MCP-getting-started.md
@@ -14,7 +14,9 @@ Getting started is easy in a variety of ways.
 
 ### GitLens
 
-With the latest version of [GitLens](https://www.gitkraken.com/gitlens) you can install the MCP Server easily from the command palette in VS Code, Cursor, and other IDEs based on VS Code.
+The GitKraken MCP server is bundled with [GitLens](https://www.gitkraken.com/gitlens) on VSCode versions `1.101.0` and greater. No action is needed to get started. 
+
+For VSCode versions older than `1.101.0` you can install the MCP Server easily from the command palette in VS Code, Cursor, and other IDEs based on VS Code.
 
 (/wp-content/uploads//install-gitlens.png)
 


### PR DESCRIPTION
Added a note that VSCode versions 1.101.0 and greater do not need to take action to install as it comes bundled with GitLens.